### PR TITLE
feat(common): add Tron deployment scripts for AuthorityManager

### DIFF
--- a/common/.env.example
+++ b/common/.env.example
@@ -4,7 +4,14 @@
 # IMPORTANT: Never commit your actual .env file with real private keys!
 
 # Private key for deployment (without 0x prefix)
-PRIVATE_KEY=ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+# PRIVATE_KEY is used for mainnet (NETWORK_SUFFIX=main)
+PRIVATE_KEY=
+# TESTNET_PRIVATE_KEY is used for testnet
+TESTNET_PRIVATE_KEY=
+
+# Network environment: "main" for mainnet, "prod" for production
+# Controls deploy.json key suffix: Tron_main vs Tron_prod
+NETWORK_SUFFIX=prod
 
 # Mainnet RPC URLs
 ETH_RPC_URL=https://mainnet.infura.io/v3/YOUR_INFURA_KEY
@@ -14,6 +21,10 @@ ARB_RPC_URL=https://arb1.arbitrum.io/rpc
 OP_RPC_URL=https://mainnet.optimism.io
 AVAX_RPC_URL=https://api.avax.network/ext/bc/C/rpc
 BASE_RPC_URL=https://mainnet.base.org
+
+# Tron
+TRON_PRIVATE_KEY=
+TRON_RPC_URL=https://api.trongrid.io/
 
 # Testnet RPC URLs
 SEPOLIA_RPC_URL=https://sepolia.infura.io/v3/YOUR_INFURA_KEY

--- a/common/deployments/deploy.json
+++ b/common/deployments/deploy.json
@@ -1,0 +1,5 @@
+{
+	"Tron_main": {
+		"Authority": "TQaBr8DeMwchCis3Ydamkyfx27btrBgzje"
+	}
+}

--- a/common/hardhat.config.ts
+++ b/common/hardhat.config.ts
@@ -1,10 +1,12 @@
 import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-toolbox";
 import "@nomicfoundation/hardhat-foundry";
+import "dotenv/config";
+import "./tasks/index";
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.24",
+    version: "0.8.25",
     settings: {
       optimizer: {
         enabled: true,
@@ -22,7 +24,17 @@ const config: HardhatUserConfig = {
   networks: {
     hardhat: {
       chainId: 31337
-    }
+    },
+    Tron: {
+      url: process.env.TRON_RPC_URL || "https://api.trongrid.io/jsonrpc",
+      chainId: 728126428,
+      accounts: process.env.TRON_PRIVATE_KEY ? [process.env.TRON_PRIVATE_KEY] : [],
+    },
+    Tron_test: {
+      url: "https://api.nileex.io/jsonrpc",
+      chainId: 3448148188,
+      accounts: process.env.TESTNET_PRIVATE_KEY ? [process.env.TESTNET_PRIVATE_KEY] : [],
+    },
   },
   gasReporter: {
     enabled: process.env.REPORT_GAS !== undefined,

--- a/common/package.json
+++ b/common/package.json
@@ -46,8 +46,8 @@
   "author": "MAP Protocol",
   "license": "MIT",
   "dependencies": {
-    "@openzeppelin/contracts": "^5.4.0",
-    "@openzeppelin/contracts-upgradeable": "^5.4.0"
+    "@openzeppelin/contracts": "5.4.0",
+    "@openzeppelin/contracts-upgradeable": "5.4.0"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
@@ -62,8 +62,10 @@
     "@types/mocha": ">=9.1.0",
     "@types/node": ">=18.0.0",
     "chai": "^4.2.0",
+    "dotenv": "^16.0.3",
     "ethers": "^6.4.0",
     "hardhat": "^2.19.0",
+    "tronweb": "^5.3.0",
     "hardhat-gas-reporter": "^1.0.8",
     "solidity-coverage": "^0.8.0",
     "ts-node": ">=8.0.0",

--- a/common/tasks/index.ts
+++ b/common/tasks/index.ts
@@ -1,0 +1,1 @@
+import "./subs/authority";

--- a/common/tasks/subs/authority.ts
+++ b/common/tasks/subs/authority.ts
@@ -1,0 +1,174 @@
+import { task, types } from "hardhat/config";
+import { getDeploymentByKey, saveDeployment } from "../utils/utils";
+import { tronDeploy, getTronContract, tronToHex, tronFromHex, isTronNetwork } from "../utils/tronUtil";
+
+function getRole(role: string): number {
+    if (role === "root") return 0;
+    if (role === "admin") return 1;
+    if (role === "manager") return 2;
+    if (role === "minter") return 10;
+    throw "unknown role";
+}
+
+async function getAuth(hre: any, contractAddress: string) {
+    let addr = contractAddress;
+    if (addr === "" || addr === "latest") {
+        addr = await getDeploymentByKey(hre.network.name, "Authority");
+    }
+
+    let authority;
+    if (isTronNetwork(hre.network.name)) {
+        authority = await getTronContract("AuthorityManager", hre.artifacts, hre.network.name, addr);
+    } else {
+        const { ethers } = hre;
+        authority = await ethers.getContractAt("AuthorityManager", addr);
+    }
+    return authority;
+}
+
+task("auth:deploy", "deploy AuthorityManager")
+    .addOptionalParam("admin", "default admin address", "", types.string)
+    .setAction(async (taskArgs, hre) => {
+        const { network, ethers } = hre;
+        const [deployer] = await ethers.getSigners();
+        console.log("deployer address:", deployer.address);
+
+        let admin = taskArgs.admin;
+        if (admin === "") {
+            admin = deployer.address;
+        }
+
+        if (isTronNetwork(network.name)) {
+            let adminHex = await tronToHex(admin, network.name);
+            let addr = await tronDeploy("AuthorityManager", [adminHex], hre.artifacts, network.name);
+            let tronAddr = await tronFromHex(addr, network.name);
+            await saveDeployment(network.name, "Authority", tronAddr);
+            console.log(`AuthorityManager deployed: ${tronAddr}`);
+        } else {
+            const AuthorityFactory = await ethers.getContractFactory("AuthorityManager");
+            let authority = await (await AuthorityFactory.deploy(admin)).waitForDeployment();
+            let addr = await authority.getAddress();
+            await saveDeployment(network.name, "Authority", addr);
+            console.log(`AuthorityManager deployed: ${addr}`);
+        }
+    });
+
+task("auth:grant", "grant role to account")
+    .addParam("account", "account to grant role")
+    .addParam("role", "role name: admin/manager/minter")
+    .addOptionalParam("delay", "execution delay", 0, types.int)
+    .addOptionalParam("auth", "authority address", "", types.string)
+    .setAction(async (taskArgs, hre) => {
+        const { network } = hre;
+        let authority = await getAuth(hre, taskArgs.auth);
+        let role = getRole(taskArgs.role);
+
+        let account = taskArgs.account;
+        if (isTronNetwork(network.name)) {
+            account = await tronToHex(account, network.name);
+            await authority.grantRole(role, account, taskArgs.delay).send();
+        } else {
+            await (await authority.grantRole(role, account, taskArgs.delay)).wait();
+        }
+        console.log(`granted role ${taskArgs.role}(${role}) to ${taskArgs.account}`);
+    });
+
+task("auth:revoke", "revoke role from account")
+    .addParam("account", "account to revoke role")
+    .addParam("role", "role name: admin/manager/minter")
+    .addOptionalParam("auth", "authority address", "", types.string)
+    .setAction(async (taskArgs, hre) => {
+        const { network } = hre;
+        let authority = await getAuth(hre, taskArgs.auth);
+        let role = getRole(taskArgs.role);
+
+        let account = taskArgs.account;
+        if (isTronNetwork(network.name)) {
+            account = await tronToHex(account, network.name);
+            await authority.revokeRole(role, account).send();
+        } else {
+            await (await authority.revokeRole(role, account)).wait();
+        }
+        console.log(`revoked role ${taskArgs.role}(${role}) from ${taskArgs.account}`);
+    });
+
+task("auth:getMember", "get role members")
+    .addOptionalParam("role", "role name", "admin", types.string)
+    .addOptionalParam("auth", "authority address", "", types.string)
+    .setAction(async (taskArgs, hre) => {
+        let authority = await getAuth(hre, taskArgs.auth);
+        let role = getRole(taskArgs.role);
+
+        if (isTronNetwork(hre.network.name)) {
+            let count = await authority.getRoleMemberCount(role).call();
+            console.log(`role ${taskArgs.role}(${role}) has ${count} member(s)`);
+            for (let i = 0; i < count; i++) {
+                let member = await authority.getRoleMember(role, i).call();
+                console.log(`  ${i}: ${member}`);
+            }
+        } else {
+            let count = await authority.getRoleMemberCount(role);
+            console.log(`role ${taskArgs.role}(${role}) has ${count} member(s)`);
+            for (let i = 0; i < count; i++) {
+                let member = await authority.getRoleMember(role, i);
+                console.log(`  ${i}: ${member}`);
+            }
+        }
+    });
+
+task("auth:setTarget", "set target function role")
+    .addParam("target", "target contract address")
+    .addParam("funcs", "function selectors (comma-separated)")
+    .addParam("role", "role name")
+    .addOptionalParam("auth", "authority address", "", types.string)
+    .setAction(async (taskArgs, hre) => {
+        const { network } = hre;
+        let authority = await getAuth(hre, taskArgs.auth);
+        let role = getRole(taskArgs.role);
+        let funSigs = taskArgs.funcs.split(",");
+
+        let target = taskArgs.target;
+        if (isTronNetwork(network.name)) {
+            target = await tronToHex(target, network.name);
+            await authority.setTargetFunctionRole(target, funSigs, role).send();
+        } else {
+            await (await authority.setTargetFunctionRole(target, funSigs, role)).wait();
+        }
+        console.log(`set target ${taskArgs.target} functions [${funSigs}] to role ${taskArgs.role}(${role})`);
+    });
+
+task("auth:setAuth", "update target authority")
+    .addParam("target", "target contract address")
+    .addParam("addr", "new authority address")
+    .addOptionalParam("auth", "authority address", "", types.string)
+    .setAction(async (taskArgs, hre) => {
+        const { network } = hre;
+        let authority = await getAuth(hre, taskArgs.auth);
+
+        if (isTronNetwork(network.name)) {
+            let target = await tronToHex(taskArgs.target, network.name);
+            let newAuth = await tronToHex(taskArgs.addr, network.name);
+            await authority.updateAuthority(target, newAuth).send();
+        } else {
+            await (await authority.updateAuthority(taskArgs.target, taskArgs.addr)).wait();
+        }
+        console.log(`set target ${taskArgs.target} authority to ${taskArgs.addr}`);
+    });
+
+task("auth:closeTarget", "close/open target")
+    .addParam("target", "target contract address")
+    .addParam("close", "true to close, false to open")
+    .addOptionalParam("auth", "authority address", "", types.string)
+    .setAction(async (taskArgs, hre) => {
+        const { network } = hre;
+        let authority = await getAuth(hre, taskArgs.auth);
+        let close = taskArgs.close === "true";
+
+        if (isTronNetwork(network.name)) {
+            let target = await tronToHex(taskArgs.target, network.name);
+            await authority.setTargetClosed(target, close).send();
+        } else {
+            await (await authority.setTargetClosed(taskArgs.target, close)).wait();
+        }
+        console.log(`set target ${taskArgs.target} closed: ${close}`);
+    });

--- a/common/tasks/utils/tronUtil.ts
+++ b/common/tasks/utils/tronUtil.ts
@@ -1,0 +1,68 @@
+let TronWeb = require("tronweb");
+
+export async function tronDeploy(contractName: string, args: any[], artifacts: any, network: string) {
+    let c = await artifacts.readArtifact(contractName);
+    let tronWeb = await getTronWeb(network);
+    console.log("deploy address is:", tronWeb.defaultAddress);
+    let contract_instance = await tronWeb.contract().new({
+        abi: c.abi,
+        bytecode: c.bytecode,
+        feeLimit: 15000000000,
+        callValue: 0,
+        parameters: args,
+    });
+    let contract_address = tronWeb.address.fromHex(contract_instance.address);
+    console.log(`${contractName} deployed on: ${contract_address} (${contract_instance.address})`);
+    return "0x" + contract_instance.address.substring(2);
+}
+
+export async function getTronContract(contractName: string, artifacts: any, network: string, addr: string) {
+    let tronWeb = await getTronWeb(network);
+    console.log("operator address is:", tronWeb.defaultAddress);
+    let C = await artifacts.readArtifact(contractName);
+    let c = await tronWeb.contract(C.abi, addr);
+    return c;
+}
+
+export async function getTronDeployer(hex: boolean, network: string) {
+    let tronWeb = await getTronWeb(network);
+    if (hex) {
+        return tronWeb.defaultAddress.hex.replace(/^(41)/, "0x");
+    } else {
+        return tronWeb.defaultAddress;
+    }
+}
+
+export async function tronFromHex(hex: string, network: string) {
+    let tronWeb = await getTronWeb(network);
+    return tronWeb.address.fromHex(hex);
+}
+
+export async function tronToHex(addr: string, network: string) {
+    let tronWeb = await getTronWeb(network);
+    return tronWeb.address.toHex(addr).replace(/^(41)/, "0x");
+}
+
+export function isTronNetwork(network: string): boolean {
+    return network === "Tron" || network === "tron_test";
+}
+
+export async function getTronWeb(network: string) {
+    if (network === "Tron" || network === "Tron_test") {
+        if (network === "Tron") {
+            return new TronWeb({
+                fullHost: process.env.TRON_RPC_URL,
+                privateKey: process.env.TRON_PRIVATE_KEY,
+            });
+        } else {
+            return new TronWeb(
+                "https://api.nileex.io/",
+                "https://api.nileex.io/",
+                "https://api.nileex.io/",
+                process.env.TRON_PRIVATE_KEY,
+            );
+        }
+    } else {
+        throw "unsupported network";
+    }
+}

--- a/common/tasks/utils/utils.ts
+++ b/common/tasks/utils/utils.ts
@@ -1,0 +1,61 @@
+let fs = require("fs");
+let path = require("path");
+import "@nomicfoundation/hardhat-ethers";
+
+export function getNetworkName(network: string) {
+    if (network.indexOf("test") > 0) return network;
+    let suffix = process.env.NETWORK_SUFFIX;
+    if (suffix === "main") {
+        return network + "_" + "main";
+    } else {
+        return network + "_" + "prod";
+    }
+}
+
+type Deployment = {
+    [network: string]: {
+        [key: string]: any;
+    };
+};
+
+export async function getDeploymentByKey(network: string, key: string) {
+    network = getNetworkName(network);
+    let deployment = await readDeploymentFromFile(network);
+    let deployAddress = deployment[network][key];
+    if (!deployAddress) throw `no ${key} deployment in ${network}`;
+    return deployAddress;
+}
+
+async function readDeploymentFromFile(network: string): Promise<Deployment> {
+    let p = path.join(__dirname, "../../deployments/deploy.json");
+    let deploy: Deployment;
+    if (!fs.existsSync(p)) {
+        deploy = {};
+        deploy[network] = {};
+    } else {
+        let rawdata = fs.readFileSync(p, "utf-8");
+        deploy = JSON.parse(rawdata);
+        if (!deploy[network]) {
+            deploy[network] = {};
+        }
+    }
+    return deploy;
+}
+
+export async function saveDeployment(network: string, key: string, addr: string) {
+    network = getNetworkName(network);
+    let deployment = await readDeploymentFromFile(network);
+    deployment[network][key] = addr;
+    let p = path.join(__dirname, "../../deployments/deploy.json");
+    await folder("../../deployments/");
+    fs.writeFileSync(p, JSON.stringify(deployment, null, "\t"));
+}
+
+const folder = async (reaPath: string) => {
+    const absPath = path.resolve(__dirname, reaPath);
+    try {
+        await fs.promises.stat(absPath);
+    } catch (e) {
+        await fs.promises.mkdir(absPath, { recursive: true });
+    }
+};


### PR DESCRIPTION
Add Hardhat tasks for deploying and managing AuthorityManager on Tron:
- auth:deploy — deploy AuthorityManager (supports Tron + EVM)
- auth:grant/revoke — role management
- auth:getMember — query role members
- auth:setTarget — set function-level role access
- auth:setAuth — update target contract authority
- auth:closeTarget — close/open target

Includes:
- tasks/utils/tronUtil.ts — TronWeb utilities (deploy, contract interaction)
- tasks/utils/utils.ts — deployment address management (main/prod env support)
- Tron network config in hardhat.config.ts
- dotenv + tronweb dependencies